### PR TITLE
Mark `socat` with CAP_NET_BIND_SERVICE capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
 
-RUN apk --no-cache add socat
+RUN apk --no-cache add socat libcap \
+ && setcap 'cap_net_bind_service=+ep' /usr/bin/socat \
+ && apk del libcap
 
 ENTRYPOINT ["socat"]


### PR DESCRIPTION
Allow `socat` to bind to privileged ports inside of the container when run as user process.
Example command-line: `docker run --rm --user "2004" --cap-add NET_BIND_SERVICE socat tcp6-listen:443,fork tcp4:mail:443`

If `--cap-add NET_BIND_SERVICE` is not set then this change does nothing.

I guess documentation should be also updated to recommend this by default, since privilege dropping is always good.