### PR TITLE
Add `ignoreeof` flag to socat tcp listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ docker run -d --restart=always \
     -p 127.0.0.1:2376:2375 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     alpine/socat \
-    tcp-listen:2375,fork,reuseaddr unix-connect:/var/run/docker.sock
+    tcp-listen:2375,fork,reuseaddr,ignoreeof unix-connect:/var/run/docker.sock
 ```
 
 ***WARNING***: The Docker API is insecure by default. Please remember to bind the TCP socket to the `localhost` interface otherwise the Docker API will be bound to all interfaces.


### PR DESCRIPTION
After a maddening few hours of using `socat` as a proxy to the docker socket and wondering why `docker run` would inconsistently fail to return any output I found it was due to the unfortunate behaviour of `socat` and the `docker` cli. 

I believe that the docker client is leaving the socket half-open which triggers socat to timeout (after 0.5s by default) if there is no data to read from the opposite direction. Increasing the timeout (`socat -t10`) worked but ignoring the EOF entirely seems more robust.